### PR TITLE
Override istio-default profile and remove fmp-project

### DIFF
--- a/service-a/src/main/fabric8/profiles.yml
+++ b/service-a/src/main/fabric8/profiles.yml
@@ -1,0 +1,38 @@
+# Profile containing Istio enricher
+# The istio-default profile is defined in the Istio enricher but is overridden here
+# we need to remove the fmp-project enricher that messes up labels and selectors
+- name: istio-default
+  enricher:
+    includes:
+    - fmp-name
+    - fmp-controller
+    - fmp-service
+    - fmp-image
+    - fmp-portname
+    - fmp-pod-annotations
+    - fmp-debug
+    - fmp-merge
+    - fmp-remove-build-annotations
+    - fmp-volume-permission
+    - f8-expose
+    - fmp-istio-enricher
+    # Health checks
+    - spring-boot-health-check
+    - docker-health-check
+    - fmp-dependency
+    - f8-watch
+    excludes:
+    - fmp-openshift-route
+    - fmp-project
+    config:
+      fmp-istio-enricher:
+        istioVersion: "0.6.0"
+        enableCoreDump: "false"
+
+  generator:
+    includes:
+    - spring-boot
+  watcher:
+    includes:
+    - spring-boot
+    - docker-image

--- a/service-b/src/main/fabric8/profiles.yml
+++ b/service-b/src/main/fabric8/profiles.yml
@@ -1,0 +1,38 @@
+# Profile containing Istio enricher
+# The istio-default profile is defined in the Istio enricher but is overridden here
+# we need to remove the fmp-project enricher that messes up labels and selectors
+- name: istio-default
+  enricher:
+    includes:
+    - fmp-name
+    - fmp-controller
+    - fmp-service
+    - fmp-image
+    - fmp-portname
+    - fmp-pod-annotations
+    - fmp-debug
+    - fmp-merge
+    - fmp-remove-build-annotations
+    - fmp-volume-permission
+    - f8-expose
+    - fmp-istio-enricher
+    # Health checks
+    - spring-boot-health-check
+    - docker-health-check
+    - fmp-dependency
+    - f8-watch
+    excludes:
+    - fmp-openshift-route
+    - fmp-project
+    config:
+      fmp-istio-enricher:
+        istioVersion: "0.6.0"
+        enableCoreDump: "false"
+
+  generator:
+    includes:
+    - spring-boot
+  watcher:
+    includes:
+    - spring-boot
+    - docker-image


### PR DESCRIPTION
We need to remove the fmp-project enricher because it creates selectors
(which we don't want) be default